### PR TITLE
Fix compile against live iOS 9 SDK

### DIFF
--- a/Taptronome Extension/InterfaceController.m
+++ b/Taptronome Extension/InterfaceController.m
@@ -36,7 +36,7 @@
 
 - (void)willActivate {
     [super willActivate];
-    [self.bpmPicker focusForCrownInput];
+    [self.bpmPicker focus];
     [self updateUI];
 }
 


### PR DESCRIPTION
I found your sample code and tried to run it on my watch, discovered Apple changed the focusForCrownInput to focus in the final version. Here's a fix that will let your sample build.
